### PR TITLE
Increase block reward to 12500

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -331,7 +331,7 @@ BlockController.prototype.formatTimestamp = function(date) {
 };
 
 BlockController.prototype.getBlockReward = function(height) {
-  var subsidy = new BN(12.5 * 1e8);
+  var subsidy = new BN(12500 * 1e8);
 
   // Mining slow start
   // The subsidy is ramped up linearly, skipping the middle payout of

--- a/test/blocks.js
+++ b/test/blocks.js
@@ -64,7 +64,7 @@ describe('Blocks', function() {
       'chainwork': '0000000000000000000000000000000000000000000000054626b1839ade284a',
       'previousblockhash': '00000000000001a55f3214e9172eb34b20e0bc5bd6b8007f3f149fca2c8991a4',
       'nextblockhash': '000000000001e866a8057cde0c650796cb8a59e0e6038dc31c69d7ca6649627d',
-      'reward': 12.5,
+      'reward': 12500,
       'isMainChain': true,
       'poolInfo': {}
     };
@@ -267,8 +267,8 @@ describe('Blocks', function() {
       blocks.getBlockReward(373011).should.equal(25 * 1e8);
     });
 
-    it('should give a block reward of 12.5 * 1e8 for block between second and third halvenings', function() {
-      blocks.getBlockReward(500000).should.equal(12.5 * 1e8);
+    it('should give a block reward of 12500 * 1e8 for block between second and third halvenings', function() {
+      blocks.getBlockReward(500000).should.equal(12500 * 1e8);
     });
   });
 });


### PR DESCRIPTION
Previously the block reward was set to 12.5 BTCz, which was incorrect.
This commit sets the reward to what it should be at 12500 BTCz.